### PR TITLE
Allow querying draft and future (sub)themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version [3.6.3] (2023-01-11)
+
+### Feat
+
+-   Allow querying draft and future (sub)themes
+
 ## Version [3.6.2] (2022-12-23)
 
 ### Feat

--- a/pdc-base.php
+++ b/pdc-base.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Yard | PDC Base
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Acts as foundation for other PDC related content plugins. This plugin implements actions to allow for other plugins to add and/or change Custom Posttypes, Metaboxes, Taxonomies, en Posts 2 posts relations.
- * Version:           3.6.2
+ * Version:           3.6.3
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0

--- a/src/Base/Admin/AdminServiceProvider.php
+++ b/src/Base/Admin/AdminServiceProvider.php
@@ -37,7 +37,7 @@ class AdminServiceProvider extends ServiceProvider
     {
         if (
             ! in_array($post->post_type, ['pdc-item', 'pdc-category', 'pdc-subcategory']) ||
-            !$this->plugin->settings->isPortalSlugValid()
+            ! $this->plugin->settings->isPortalSlugValid()
         ) {
             return $link;
         }

--- a/src/Base/Admin/AdminServiceProvider.php
+++ b/src/Base/Admin/AdminServiceProvider.php
@@ -35,7 +35,10 @@ class AdminServiceProvider extends ServiceProvider
      */
     public function filterPreviewLink(string $link, \WP_Post $post): string
     {
-        if ($post->post_type !== 'pdc-item' || !$this->plugin->settings->isPortalSlugValid()) {
+        if (
+            ! in_array($post->post_type, ['pdc-item', 'pdc-category', 'pdc-subcategory']) ||
+            !$this->plugin->settings->isPortalSlugValid()
+        ) {
             return $link;
         }
 

--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -17,7 +17,7 @@ class Plugin
      *
      * @var string
      */
-    const VERSION = '3.6.2';
+    const VERSION = '3.6.3';
 
     /**
      * Path to the root of the plugin.

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -17,15 +17,11 @@ abstract class BaseController
 {
     /**
      * Instance of the plugin.
-     *
-     * @var Plugin
      */
-    protected $plugin;
+    protected Plugin $plugin;
 
     /**
      * Construction, with dependency injection of the BasePlugin.
-     *
-     * @param Plugin $plugin
      *
      * @return void
      */
@@ -36,11 +32,6 @@ abstract class BaseController
 
     /**
      * Merges a paginator, based on a WP_Query, inside a data arary.
-     *
-     * @param array    $data
-     * @param WP_Query $query
-     *
-     * @return array
      */
     protected function addPaginator(array $data, WP_Query $query): array
     {
@@ -61,13 +52,8 @@ abstract class BaseController
 
     /**
      * Get the paginator query params for a given query.
-     *
-     * @param WP_REST_Request $request
-     * @param int             $limit
-     *
-     * @return array
      */
-    protected function getPaginatorParams(WP_REST_Request $request, int $limit = 10)
+    protected function getPaginatorParams(WP_REST_Request $request, int $limit = 10): array
     {
         return [
             'posts_per_page' => $request->get_param('limit') ?: $limit,
@@ -77,10 +63,6 @@ abstract class BaseController
 
     /**
      * Return the post status to query on.
-     *
-     * @param  WP_REST_Request $request
-     *
-     * @return array
      */
     protected function getPostStatus(WP_REST_Request $request): array
     {

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Controller which handels general quering, such as pagination.
  */
@@ -72,5 +73,19 @@ abstract class BaseController
             'posts_per_page' => $request->get_param('limit') ?: $limit,
             'paged'          => $request->get_param('page') ?: 0
         ];
+    }
+
+    /**
+     * Return the post status to query on.
+     *
+     * @param  WP_REST_Request $request
+     *
+     * @return array
+     */
+    protected function getPostStatus(WP_REST_Request $request): array
+    {
+        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
+
+        return $preview ? ['publish', 'draft', 'future'] : ['publish'];
     }
 }

--- a/src/Base/RestAPI/Controllers/GroupController.php
+++ b/src/Base/RestAPI/Controllers/GroupController.php
@@ -15,15 +15,10 @@ use WP_REST_Request;
  */
 class GroupController extends BaseController
 {
-
     /**
      * Get a list of all subthemas.
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return void
      */
-    public function getGroups(WP_REST_Request $request)
+    public function getGroups(WP_REST_Request $request): array
     {
         $items = (new Group)
             ->query(apply_filters('owc/pdc/rest-api/group/query', $this->getPaginatorParams($request)))
@@ -37,8 +32,6 @@ class GroupController extends BaseController
 
     /**
      * Get an individual subthema.
-     *
-     * @param $request $request
      *
      * @return array|WP_Error
      */

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -20,12 +20,8 @@ class ItemController extends BaseController
 
     /**
      * Get a list of all items.
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return array
      */
-    public function getItems(WP_REST_Request $request)
+    public function getItems(WP_REST_Request $request): array
     {
         $parameters = $this->convertParameters($request->get_params());
         $items      = (new Item())
@@ -45,10 +41,6 @@ class ItemController extends BaseController
 
     /**
      * Convert the parameters to the allowed ones.
-     *
-     * @param array $parametersFromRequest
-     *
-     * @return array
      */
     protected function convertParameters(array $parametersFromRequest): array
     {
@@ -75,8 +67,6 @@ class ItemController extends BaseController
 
     /**
      * Get an individual post item.
-     *
-     * @param WP_Rest_Request $request
      *
      * @return array|WP_Error
      */
@@ -105,8 +95,6 @@ class ItemController extends BaseController
 
     /**
      * Get an individual post item by slug.
-     *
-     * @param WP_Rest_Request $request
      *
      * @return array|WP_Error
      */

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -137,15 +137,10 @@ class ItemController extends BaseController
 
     public function buildQueryFromRequest(WP_REST_Request $request): Item
     {
-        $item = (new Item)
+        $item = (new Item())
             ->query(apply_filters('owc/pdc/rest-api/items/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
             ->query(self::excludeInactiveItems());
-
-        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
-        
-        if (true === $preview) {
-            $item->query(['post_status' => ['publish', 'draft', 'future']]);
-        }
 
         $password = esc_attr($request->get_param('password'));
         if (!empty($password)) {

--- a/src/Base/RestAPI/Controllers/SearchController.php
+++ b/src/Base/RestAPI/Controllers/SearchController.php
@@ -16,12 +16,8 @@ class SearchController extends ItemController
 {
     /**
      * Get a list of all items.
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return array
      */
-    public function search(WP_REST_Request $request)
+    public function search(WP_REST_Request $request): array
     {
         $items = (new Item())
             ->hide(['connected'])
@@ -58,10 +54,8 @@ class SearchController extends ItemController
 
     /**
      * Get an individual post item.
-     *
-     * @return array
      */
-    public function arguments()
+    public function arguments(): array
     {
         $args      = [];
         $args['s'] = [

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -15,15 +15,10 @@ use WP_REST_Request;
  */
 class SubthemaController extends BaseController
 {
-
     /**
      * Get a list of all subthemas.
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return void
      */
-    public function getSubthemas(WP_REST_Request $request)
+    public function getSubthemas(WP_REST_Request $request): array
     {
         $items = (new Subthema())
             ->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
@@ -41,8 +36,6 @@ class SubthemaController extends BaseController
 
     /**
      * Get an individual subthema.
-     *
-     * @param $request $request
      *
      * @return array|WP_Error
      */
@@ -66,8 +59,6 @@ class SubthemaController extends BaseController
 
     /**
      * Get an individual subtheme by slug.
-     *
-     * @param WP_Rest_Request $request
      *
      * @return array|WP_Error
      */

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -25,9 +25,13 @@ class SubthemaController extends BaseController
      */
     public function getSubthemas(WP_REST_Request $request)
     {
-        $items = (new Subthema)
+        $items = (new Subthema())
             ->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
-            ->query(['orderby' => 'name', 'order' => 'ASC']);
+            ->query([
+                'order'         => 'ASC',
+                'orderby'       => 'name',
+                'post_status'   => $this->getPostStatus($request)
+            ]);
 
         $data  = $items->all();
         $query = $items->getQuery();
@@ -46,8 +50,9 @@ class SubthemaController extends BaseController
     {
         $id = (int) $request->get_param('id');
 
-        $thema = (new Subthema)
+        $thema = (new Subthema())
             ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
             ->find($id);
 
         if (!$thema) {
@@ -70,8 +75,9 @@ class SubthemaController extends BaseController
     {
         $slug = $request->get_param('slug');
 
-        $subtheme = (new Subthema)
+        $subtheme = (new Subthema())
             ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
             ->findBySlug($slug);
 
 
@@ -84,5 +90,19 @@ class SubthemaController extends BaseController
         }
 
         return $subtheme;
+    }
+
+    /**
+     * Return the post status to query on.
+     *
+     * @param  WP_REST_Request $request
+     *
+     * @return array
+     */
+    protected function getPostStatus(WP_REST_Request $request): array
+    {
+        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
+
+        return $preview ? ['publish', 'draft', 'future'] : ['publish'];
     }
 }

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -91,18 +91,4 @@ class SubthemaController extends BaseController
 
         return $subtheme;
     }
-
-    /**
-     * Return the post status to query on.
-     *
-     * @param  WP_REST_Request $request
-     *
-     * @return array
-     */
-    protected function getPostStatus(WP_REST_Request $request): array
-    {
-        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
-
-        return $preview ? ['publish', 'draft', 'future'] : ['publish'];
-    }
 }

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -94,18 +94,4 @@ class ThemaController extends BaseController
 
         return $theme;
     }
-
-    /**
-     * Return the post status to query on.
-     *
-     * @param  WP_REST_Request $request
-     *
-     * @return array
-     */
-    protected function getPostStatus(WP_REST_Request $request): array
-    {
-        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
-
-        return $preview ? ['publish', 'draft', 'future'] : ['publish'];
-    }
 }

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -15,15 +15,10 @@ use WP_REST_Request;
  */
 class ThemaController extends BaseController
 {
-
     /**
      * Get a list of all themas.
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return void
      */
-    public function getThemas(WP_REST_Request $request)
+    public function getThemas(WP_REST_Request $request): array
     {
         $orderBy = $request->get_param('orderby') ?? 'title';
         $order   = $request->get_param('order') ?? 'ASC';
@@ -45,8 +40,6 @@ class ThemaController extends BaseController
 
     /**
      * Get an individual thema.
-     *
-     * @param WP_REST_Request $request
      *
      * @return array|WP_Error
      */
@@ -70,8 +63,6 @@ class ThemaController extends BaseController
 
     /**
      * Get an individual theme by slug.
-     *
-     * @param WP_Rest_Request $request
      *
      * @return array|WP_Error
      */

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -27,11 +27,13 @@ class ThemaController extends BaseController
     {
         $orderBy = $request->get_param('orderby') ?? 'title';
         $order   = $request->get_param('order') ?? 'ASC';
-        $items   = (new Thema)
+
+        $items   = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query', $this->getPaginatorParams($request)))
             ->query([
-                'order'   => $order,
-                'orderby' => $orderBy,
+                'order'         => $order,
+                'orderby'       => $orderBy,
+                'post_status'   => $this->getPostStatus($request)
             ])
             ->hide(['items']);
 
@@ -52,8 +54,9 @@ class ThemaController extends BaseController
     {
         $id = (int) $request->get_param('id');
 
-        $thema = (new Thema)
+        $thema = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
             ->find($id);
 
         if (!$thema) {
@@ -76,8 +79,9 @@ class ThemaController extends BaseController
     {
         $slug = $request->get_param('slug');
 
-        $theme = (new Thema)
+        $theme = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
             ->findBySlug($slug);
 
         if (! $theme) {
@@ -89,5 +93,19 @@ class ThemaController extends BaseController
         }
 
         return $theme;
+    }
+
+    /**
+     * Return the post status to query on.
+     *
+     * @param  WP_REST_Request $request
+     *
+     * @return array
+     */
+    protected function getPostStatus(WP_REST_Request $request): array
+    {
+        $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
+
+        return $preview ? ['publish', 'draft', 'future'] : ['publish'];
     }
 }

--- a/src/Base/RestAPI/RestAPIServiceProvider.php
+++ b/src/Base/RestAPI/RestAPIServiceProvider.php
@@ -14,7 +14,6 @@ use WP_REST_Server;
  */
 class RestAPIServiceProvider extends ServiceProvider
 {
-
     /**
      * The endpoint of the base API.
      *


### PR DESCRIPTION
This PR adds the same draft/future `post_status` query of PDC Items to (sub)themes. 

Is this ok to merge? If it is, we might want to move the `getPostStatus()` method to the `OWC\PDC\Base\RestAPI\Controllers\BaseController` class as it will reduce code duplication.