### PR TITLE
(feat:) in the REST API controllers support passing all request params to WP_Query

### DIFF
--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -55,10 +55,10 @@ abstract class BaseController
      */
     protected function getPaginatorParams(WP_REST_Request $request, int $limit = 10): array
     {
-        return [
+        return array_merge($request->get_params(), [
             'posts_per_page' => $request->get_param('limit') ?: $limit,
             'paged' => $request->get_param('page') ?: 0
-        ];
+        ]);
     }
 
     /**

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -6,9 +6,9 @@
 
 namespace OWC\PDC\Base\RestAPI\Controllers;
 
+use OWC\PDC\Base\Foundation\Plugin;
 use WP_Query;
 use WP_REST_Request;
-use OWC\PDC\Base\Foundation\Plugin;
 
 /**
  * Controller which handels general quering, such as pagination.
@@ -39,14 +39,14 @@ abstract class BaseController
         $page = 0 == $page ? 1 : $page;
 
         return array_merge([
-            'data' => $data
+            'data' => $data,
         ], [
             'pagination' => [
-                'total_count' => (int) $query->found_posts,
-                'total_pages' => $query->max_num_pages,
+                'total_count'  => (int) $query->found_posts,
+                'total_pages'  => $query->max_num_pages,
                 'current_page' => $page,
-                'limit' => $query->get('posts_per_page')
-            ]
+                'limit'        => $query->get('posts_per_page'),
+            ],
         ]);
     }
 
@@ -55,10 +55,29 @@ abstract class BaseController
      */
     protected function getPaginatorParams(WP_REST_Request $request, int $limit = 10): array
     {
-        return array_merge($request->get_params(), [
+        $params = array_merge($request->get_params(), [
             'posts_per_page' => $request->get_param('limit') ?: $limit,
-            'paged' => $request->get_param('page') ?: 0
+            'paged'          => $request->get_param('page') ?: 0,
         ]);
+
+        return $this->validateQueryParams($params);
+    }
+
+    protected function validateQueryParams(array $params): array
+    {
+        $allowedQueryParams = [
+            'include-connected',
+            'tax_query',
+            'meta_query',
+            'posts_per_page',
+            'paged',
+            'post_type',
+            'post_status',
+        ];
+
+        return array_filter($params, function ($param) use ($allowedQueryParams) {
+            return in_array($param, $allowedQueryParams);
+        }, ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Base/RestAPI/SharedFields/ItemsField.php
+++ b/src/Base/RestAPI/SharedFields/ItemsField.php
@@ -6,10 +6,10 @@
 
 namespace OWC\PDC\Base\RestAPI\SharedFields;
 
-use WP_Post;
-use OWC\PDC\Base\Support\Traits\QueryHelpers;
-use OWC\PDC\Base\Support\Traits\CheckPluginActive;
 use OWC\PDC\Base\RestAPI\ItemFields\ConnectedField;
+use OWC\PDC\Base\Support\Traits\CheckPluginActive;
+use OWC\PDC\Base\Support\Traits\QueryHelpers;
+use WP_Post;
 
 /**
  * Adds connected fields to item in API.
@@ -44,7 +44,7 @@ class ItemsField extends ConnectedField
         }
 
         $query['connected_query'] = [
-            'post_status' => ['publish', 'draft'],
+            'post_status' => ['publish', 'draft'], // Draft only for logged in users?
         ];
 
         return $query;


### PR DESCRIPTION
Ik heb het doorgeven van de params uit het request nu net zo gedaan als in de OpenPub-plugin gebeurt (in `\OWC\OpenPub\Base\RestAPI\Controllers\BaseController::getPaginatorParams()`).

Sommige van de controllers doen na die aanroep nog andere dingen om de `AbstractRepository::$queryArgs` vervolgens nog te manipuleren/overschrijven (bijv. in `ItemController::convertParameters()`), maar door deze wijziging kunnen in principe alle params uit het request (zoals `tax_query` en `meta_query`) aan `WP_Query` doorgegeven worden.