### PR TITLE
Items op taal filteren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Version [3.10] (2024-01-10)
+
+### Feat
+
+-   Enable filtering the items of categories and sub-categories by language.
+-   Add the language of connected PDC items in the API response data.
+
+
 ## Version [3.9.1] (2024-01-02)
 
 ### Refactor

--- a/pdc-base.php
+++ b/pdc-base.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Yard | PDC Base
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Acts as foundation for other PDC related content plugins. This plugin implements actions to allow for other plugins to add and/or change Custom Posttypes, Metaboxes, Taxonomies, en Posts 2 posts relations.
- * Version:           3.9.1
+ * Version:           3.10
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0

--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -19,7 +19,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '3.9.1';
+    public const VERSION = '3.10';
 
     /**
      * Path to the root of the plugin.

--- a/src/Base/Repositories/AbstractRepository.php
+++ b/src/Base/Repositories/AbstractRepository.php
@@ -271,7 +271,6 @@ abstract class AbstractRepository
             'content' => $this->isAllowed($post) ? apply_filters('the_content', $post->post_content) : "",
             'excerpt' => $this->isAllowed($post) ? $post->post_excerpt : "",
             'date' => $post->post_date,
-            'slug' => $post->post_name,
             'post_status' => $post->post_status,
             'protected' => ! $this->isAllowed($post)
         ];

--- a/src/Base/Repositories/AbstractRepository.php
+++ b/src/Base/Repositories/AbstractRepository.php
@@ -350,6 +350,12 @@ abstract class AbstractRepository
                 }
             }
 
+            if ($this->shouldFilterLanguage()) {
+                if (method_exists($field['creator'], 'setLanguage')) {
+                    $field['creator']->setLanguage($this->language);
+                }
+            }
+
             if (is_null($field['conditional'])) {
                 // If the field has no conditional set we will add it
                 $data[$field['key']] = $field['creator']->create($post);

--- a/src/Base/Repositories/AbstractRepository.php
+++ b/src/Base/Repositories/AbstractRepository.php
@@ -62,11 +62,15 @@ abstract class AbstractRepository
      */
     protected $password = '';
 
-
     /**
      * Source for filtering the 'show_on' taxonomy
      */
     protected int $source = 0;
+
+    /**
+     * Language for filtering
+     */
+    protected ?string $language = null;
 
     /**
      * Additional fields that needs to be added to an item.
@@ -389,5 +393,17 @@ abstract class AbstractRepository
     public function shouldFilterSource(): bool
     {
         return 0 !== $this->source;
+    }
+
+    public function filterLanguage(string $language): self
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    public function shouldFilterLanguage(): bool
+    {
+        return !empty($this->language);
     }
 }

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -32,6 +32,10 @@ class SubthemaController extends BaseController
             $items->filterSource($request->get_param('source'));
         }
 
+		if ($language = $request->get_param('language')) {
+			$items->filterLanguage((string) $language);
+		}
+
         $data = $items->all();
         $query = $items->getQuery();
 
@@ -54,6 +58,10 @@ class SubthemaController extends BaseController
         if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
             $thema->filterSource($request->get_param('source'));
         }
+
+		if ($language = $request->get_param('language')) {
+			$thema->filterLanguage((string) $language);
+		}
 
         $thema = $thema->find($id);
 
@@ -82,6 +90,10 @@ class SubthemaController extends BaseController
         if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
             $subtheme->filterSource($request->get_param('source'));
         }
+
+		if ($language = $request->get_param('language')) {
+			$subtheme->filterLanguage((string) $language);
+		}
 
         $subtheme = $subtheme->findBySlug($slug);
 

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -36,6 +36,10 @@ class ThemaController extends BaseController
             $items->filterSource($request->get_param('source'));
         }
 
+		if ($language = $request->get_param('language')) {
+			$items->filterLanguage((string) $language);
+		}
+
         $data = $items->all();
         $query = $items->getQuery();
 
@@ -59,7 +63,11 @@ class ThemaController extends BaseController
             $thema->filterSource($request->get_param('source'));
         }
 
-        $thema = $thema->find($id);
+		if ($language = $request->get_param('language')) {
+			$thema->filterLanguage((string) $language);
+		}
+
+		$thema = $thema->find($id);
 
         if (! $thema) {
             return new WP_Error('no_item_found', sprintf('Thema with ID [%d] not found', $id), [
@@ -86,6 +94,10 @@ class ThemaController extends BaseController
         if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
             $theme->filterSource($request->get_param('source'));
         }
+
+		if ($language = $request->get_param('language')) {
+			$theme->filterLanguage((string) $language);
+		}
 
         $theme = $theme->findBySlug($slug);
 

--- a/src/Base/RestAPI/ItemFields/ConnectedField.php
+++ b/src/Base/RestAPI/ItemFields/ConnectedField.php
@@ -100,6 +100,7 @@ class ConnectedField extends CreatesFields
                 'slug' => $post->post_name,
                 'excerpt' => $post->post_excerpt,
                 'date' => $post->post_date,
+                'language' => get_post_meta($post->ID, '_owc_pdc-item-language', true) ?: 'nl',
             ];
 
             if ($type === 'pdc-item_to_pdc-item') {

--- a/src/Base/RestAPI/SharedFields/ItemsField.php
+++ b/src/Base/RestAPI/SharedFields/ItemsField.php
@@ -48,6 +48,10 @@ class ItemsField extends ConnectedField
             $query = array_merge_recursive($query, $this->filterShowOnTaxonomyQuery($this->source));
         }
 
+        if ($this->shouldFilterLanguage()) {
+            $query = array_merge_recursive($query, $this->filterLanguageQuery($this->language));
+        }
+
 		$query['connected_query'] = [
             'post_status' => ['publish', 'draft'],
         ];

--- a/src/Base/RestAPI/SharedFields/ItemsField.php
+++ b/src/Base/RestAPI/SharedFields/ItemsField.php
@@ -19,6 +19,11 @@ class ItemsField extends ConnectedField
     use CheckPluginActive;
     use QueryHelpers;
 
+	/**
+	 * Language for filtering
+	 */
+	protected ?string $language = null;
+
     /**
      * Creates an array of connected posts.
      */
@@ -33,9 +38,9 @@ class ItemsField extends ConnectedField
     {
         $query = [];
 
-        $query = array_merge_recursive($query, $this->excludeInactiveItemsQuery());
+		$query = array_merge_recursive($query, $this->excludeInactiveItemsQuery());
 
-        if ($this->isPluginPDCInternalProductsActive()) {
+		if ($this->isPluginPDCInternalProductsActive()) {
             $query = array_merge_recursive($query, $this->excludeInternalItemsQuery());
         }
 
@@ -43,10 +48,22 @@ class ItemsField extends ConnectedField
             $query = array_merge_recursive($query, $this->filterShowOnTaxonomyQuery($this->source));
         }
 
-        $query['connected_query'] = [
+		$query['connected_query'] = [
             'post_status' => ['publish', 'draft'],
         ];
 
         return $query;
     }
+
+	public function setLanguage(string $language): self
+	{
+		$this->language = $language;
+
+		return $this;
+	}
+
+	protected function shouldFilterLanguage(): bool
+	{
+		return !empty($this->language);
+	}
 }

--- a/src/Base/Support/Traits/QueryHelpers.php
+++ b/src/Base/Support/Traits/QueryHelpers.php
@@ -51,4 +51,41 @@ trait QueryHelpers
             ]
         ];
     }
+
+	public function filterLanguageQuery(string $language): array
+	{
+		if ($language === 'nl') {
+			return [
+				'meta_query' => [
+					[
+						'relation' => 'OR',
+						[
+							'key' => '_owc_pdc-item-language',
+							'value' => $language,
+							'compare' => '=',
+						],
+						[
+							'key' => '_owc_pdc-item-language',
+							'value' => '',
+							'compare' => '=',
+						],
+						[
+							'key' => '_owc_pdc-item-language',
+							'compare' => 'NOT EXISTS',
+						],
+					]
+				]
+			];
+		}
+
+		return [
+			'meta_query' => [
+				[
+					'key' => '_owc_pdc-item-language',
+					'value' => $language,
+					'compare' => '=',
+				],
+			]
+		];
+	}
 }


### PR DESCRIPTION
1. Met gebruik van request-param `language=xy` in de endpoints van PDC-categorieën en -subcategorieën kunnen de daaronder vallende `items` op taal gefilterd worden.
2. Van elk "connected" PDC-item wordt nu de `language` teruggegeven in het endpoint-response-data.

Voorbeeld:
- Request `/wp-json/owc/pdc/v1/subthemes/migreren` => response:
![image](https://github.com/OpenWebconcept/plugin-pdc-base/assets/47478535/2f093945-41ad-4e65-9d18-ad040a545211)

- Request `/wp-json/owc/pdc/v1/subthemes/migreren?language=nl` => response:
![image](https://github.com/OpenWebconcept/plugin-pdc-base/assets/47478535/6fea3652-9b0a-441a-8a86-bd18d63aaa29)
