### PR TITLE
(chore): add show_in_rest arg to all taxonomies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version [3.11.1] (2024-02-19)
+
+### Feat
+
+- Add show_in_rest arg to all taxonomies.
+
 ## Version [3.11] (2024-01-23)
 
 ### Fix

--- a/config/taxonomies.php
+++ b/config/taxonomies.php
@@ -27,6 +27,7 @@ return [
                 'back_to_items' => __('← Back to tags', 'pdc-base'),
             ],
             'meta_box' => 'simple',
+			'show_in_rest' => true,
         ],
         'names' => [
             'singular' => __('Audience', 'pdc-base'),
@@ -38,7 +39,7 @@ return [
         'object_types' => ['pdc-item'],
         'args' => [
             'meta_box' => 'simple',
-            'show_in_rest' => false,
+            'show_in_rest' => true,
         ],
         'names' => [
             'singular' => __('Type', 'pdc-base'),
@@ -50,7 +51,7 @@ return [
         'object_types' => ['pdc-item'],
         'args' => [
             'meta_box' => 'simple',
-            'show_in_rest' => false,
+            'show_in_rest' => true,
         ],
         'names' => [
             'singular' => __('Aspect', 'pdc-base'),
@@ -62,7 +63,7 @@ return [
         'object_types' => ['pdc-item'],
         'args' => [
             'meta_box' => 'simple',
-            'show_in_rest' => false,
+            'show_in_rest' => true,
         ],
         'names' => [
             'singular' => __('Usage', 'pdc-base'),
@@ -74,7 +75,7 @@ return [
         'object_types' => ['pdc-item'],
         'args' => [
             'meta_box' => 'simple',
-            'show_in_rest' => false,
+            'show_in_rest' => true,
             'show_admin_column' => true,
         ],
         'names' => [
@@ -86,7 +87,7 @@ return [
     'pdc-show-on' => [
         'object_types' => ['pdc-item', 'pdc-category', 'pdc-subcategory'],
         'args' => [
-            'show_in_rest' => false,
+            'show_in_rest' => true,
             'show_admin_column' => true,
             'capabilities' => [
                 'manage_terms' => 'manage_categories',

--- a/pdc-base.php
+++ b/pdc-base.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Yard | PDC Base
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Acts as foundation for other PDC related content plugins. This plugin implements actions to allow for other plugins to add and/or change Custom Posttypes, Metaboxes, Taxonomies, en Posts 2 posts relations.
- * Version:           3.11
+ * Version:           3.11.1
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0

--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -19,7 +19,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '3.11';
+    public const VERSION = '3.11.1';
 
     /**
      * Path to the root of the plugin.
@@ -135,7 +135,7 @@ class Plugin
      */
     public function callServiceProviders(string $method, string $key = ''): void
     {
-        $offset = $key ? "core.providers.{$key}" : 'core.providers';
+        $offset   = $key ? "core.providers.{$key}" : 'core.providers';
         $services = $this->config->get($offset);
 
         foreach ($services as $service) {


### PR DESCRIPTION
Bezig met een OpenPDC ListPost (remote sources). Om de taxonomies op te halen in de editor heb ik ze nodig uit het `/wp-json/v2/` endpoint.

Zie hier: 
https://bitbucket.org/openwebconcept/gemeente-whitelabel/src/b4a836ade6b1b349487e625cded2c3d479cf8730/config/yard-blocks.php#config/yard-blocks.php-21