### PR TITLE
Correctly extract URLs from shortcodes in 'links' field of pdc-item for REST API

### DIFF
--- a/src/Base/RestAPI/ItemFields/LinksField.php
+++ b/src/Base/RestAPI/ItemFields/LinksField.php
@@ -1,12 +1,13 @@
 <?php
+
 /**
  * Adds link fields to the output.
  */
 
 namespace OWC\PDC\Base\RestAPI\ItemFields;
 
-use WP_Post;
 use OWC\PDC\Base\Support\CreatesFields;
+use WP_Post;
 
 /**
  * Adds link fields to the output.
@@ -15,18 +16,15 @@ class LinksField extends CreatesFields
 {
     /**
      * Generate the links field.
-     *
-     * @param WP_Post $post
-     *
-     * @return array
      */
     public function create(WP_Post $post): array
     {
         return array_map(function ($link) {
-            $shortcode = isset($link['pdc_links_shortcode']) ? do_shortcode($link['pdc_links_shortcode']) : '';
+            $shortcode = isset($link['pdc_links_shortcode']) ? wp_kses_post(do_shortcode($link['pdc_links_shortcode'])) : '';
             $url = isset($link['pdc_links_url']) ? esc_url($link['pdc_links_url']) : '';
+
             if (! empty($shortcode)) {
-                $url = $shortcode;
+                $url = $this->handlePossibleUrlInShortcode($shortcode);
             }
 
             return [
@@ -37,16 +35,39 @@ class LinksField extends CreatesFields
     }
 
     /**
-     * Get links of a post, if URL & title are present.
+     * Extract a URL from a shortcode or return the shortcode itself if no URL is found
+     * and the short is a URL itself.
      *
-     * @param WP_Post $post
-     *
-     * @return array
+     * Some shortcodes may contain a URL embedded within an HTML element, such as an
+     * <a> tag. This method attempts to extract the URL from the `href` attribute
+     * using a regular expression. If no valid `href` is found, the raw shortcode
+     * string is sanitized and returned as a fallback.
      */
-    private function getLinks(WP_Post $post)
+    private function handlePossibleUrlInShortcode(string $shortcode): string
     {
-        return array_filter(get_post_meta($post->ID, '_owc_pdc_links_group', true) ?: [], function ($link) {
-            return (! empty($link['pdc_links_url']) or ! empty($link['pdc_links_shortcode'])) && (! empty($link['pdc_links_title']));
+        $regex = '/href=["\']([^"\']+)["\']/';
+
+        if (preg_match($regex, $shortcode, $matches)) {
+            $url = esc_url($matches[1]);
+        } else {
+            $url = esc_url($shortcode);
+        }
+
+        return filter_var($url, FILTER_VALIDATE_URL) ?: '';
+    }
+
+    /**
+     * Get links of a post, if URL & title are present.
+     */
+    private function getLinks(WP_Post $post): array
+    {
+        $links = get_post_meta($post->ID, '_owc_pdc_links_group', true) ?: [];
+
+        return array_filter($links, function ($link) {
+            $hasUrlOrShortcode = ! empty($link['pdc_links_url']) || ! empty($link['pdc_links_shortcode']);
+            $hasTitle = ! empty($link['pdc_links_title']);
+
+            return $hasUrlOrShortcode && $hasTitle;
         });
     }
 }


### PR DESCRIPTION
Shortcodes van verscheidene OWC plugins bevatten HTML elementen zoals <a> tags.
De output hiervan is correct voor de post_content maar niet in API velden waar links in horen te staan. 

Editor PDC-item:
<img width="1242" alt="Scherm­afbeelding 2025-01-10 om 08 02 18" src="https://github.com/user-attachments/assets/a9d0a8e1-b503-47b4-959f-b495fef9a278" />

Output van zo'n shortcode:
<img width="1020" alt="Scherm­afbeelding 2025-01-10 om 08 02 33" src="https://github.com/user-attachments/assets/be318852-1f03-4449-97ae-1a1c6f1c7504" />

Voor:
<img width="814" alt="Scherm­afbeelding 2025-01-10 om 08 12 54" src="https://github.com/user-attachments/assets/d6934fcc-3425-4fc6-90f5-8a22fa977606" />

Na:
<img width="570" alt="Scherm­afbeelding 2025-01-10 om 08 09 53" src="https://github.com/user-attachments/assets/59f58880-d0dd-4f9c-97fc-c7cf26db6520" />
