### PR TITLE
Fix fatal error 

### DIFF
--- a/src/Base/Taxonomy/TaxonomyController.php
+++ b/src/Base/Taxonomy/TaxonomyController.php
@@ -11,7 +11,7 @@ class TaxonomyController
      *
      * @return void
      */
-    public function addShowOnExplanation(string $taxonomy): void
+    public static function addShowOnExplanation(string $taxonomy): void
     {
         if ('pdc-show-on' !== $taxonomy) {
             return;


### PR DESCRIPTION
Bij het gebruik van de "Tonen op" feature kreeg ik een fatal error zodra ik een term van de taxonomy pdc-show-on wilde toevoegen.

Bij OpenPub is deze functie ook static, dus dat nu hier ook toegepast.