### PR TITLE
Fix/header timeout

### DIFF
--- a/src/Base/Support/CreatesFields.php
+++ b/src/Base/Support/CreatesFields.php
@@ -135,51 +135,50 @@ abstract class CreatesFields
         return $response;
     }
 
-		protected function get_headers_curl(string $url): array
-		{
-				$ch = curl_init($url);
-				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-				curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-				curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-				curl_setopt($ch, CURLOPT_HEADER, true);
-				$response = curl_exec($ch);
+	protected function get_headers_curl(string $url): array
+	{
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+		curl_setopt($ch, CURLOPT_HEADER, true);
+		$response = curl_exec($ch);
 
-				if (curl_errno($ch)) {
-					return false;
-				}
-
-				$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-				$headers = substr($response, 0, $header_size);
-				curl_close($ch);
-
-				return $this->parse_headers($headers);
+		if (curl_errno($ch)) {
+			return false;
 		}
 
-		protected function parse_headers(string $headers): array
-		{
-				$result = [];
-				$lines = explode("\r\n", $headers);
+		$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+		$headers = substr($response, 0, $header_size);
+		curl_close($ch);
 
-				foreach ($lines as $line) {
-						if (empty($line)) {
-							continue;
-						}
+		return $this->parse_headers($headers);
+	}
 
-						$parts = explode(":", $line, 2);
-						if (count($parts) == 2) {
-								$key = strtolower(trim($parts[0]));
-								$value = trim($parts[1]);
+	protected function parse_headers(string $headers): array
+	{
+		$result = [];
+		$lines = explode("\r\n", $headers);
 
-								if (isset($result[$key])) {
-										$result[$key] = (array) $result[$key];
-										$result[$key][] = $value;
-								} else {
-										$result[$key] = $value;
-								}
-						}
+		foreach ($lines as $line) {
+			if (empty($line)) {
+				continue;
+			}
+
+			$parts = explode(":", $line, 2);
+			if (count($parts) == 2) {
+				$key = strtolower(trim($parts[0]));
+				$value = trim($parts[1]);
+
+				if (isset($result[$key])) {
+					$result[$key] = (array) $result[$key];
+					$result[$key][] = $value;
+				} else {
+					$result[$key] = $value;
 				}
-
-				return $result;
+			}
 		}
 
+		return $result;
+	}
 }

--- a/src/Base/Support/CreatesFields.php
+++ b/src/Base/Support/CreatesFields.php
@@ -121,7 +121,7 @@ abstract class CreatesFields
         }
 
         try {
-            $response = $this->get_headers_curl($url);
+            $response = $this->getHeaderCurl($url);
         } catch(Exception $e) {
             $response = false;
         }
@@ -135,7 +135,7 @@ abstract class CreatesFields
         return $response;
     }
 
-	protected function get_headers_curl(string $url): array
+	protected function getHeaderCurl(string $url): array
 	{
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -145,7 +145,7 @@ abstract class CreatesFields
 		$response = curl_exec($ch);
 
 		if (curl_errno($ch)) {
-			return false;
+			return [];
 		}
 
 		$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);


### PR DESCRIPTION
Als de get_headers een "dode" url tegen komt doet ie er meer dan een minuut over, wat dus zorgt voor timeouts omdat er voor elke url een check wordt gedaan. Deze curl request doet in principe hetzelfde maar dan sneller.

Dit is o.a. te testen door
```
$url = 'https://formulieren.s-hertogenbosch.nl/formulier/nl-NL/Burgerzaken/scSR06.aspx';
$startTime = microtime(true);
$headers = get_headers($url);
$endTime = microtime(true);
echo "Time taken: " . ($endTime - $startTime) . " seconds\n";
echo "<pre>";
var_dump($headers);
echo "</pre>";
exit; 
```
Te doen, en te vergelijken met
```
$url = 'https://formulieren.s-hertogenbosch.nl/formulier/nl-NL/Burgerzaken/scSR06.aspx';
$startTime = microtime(true);
$headers = get_headers_curl($url);
$endTime = microtime(true);
echo "Time taken: " . ($endTime - $startTime) . " seconds\n";
echo "<pre>";
var_dump($headers);
echo "</pre>";
exit; 

function get_headers_curl($url)
{
    $ch = curl_init($url);
    curl_setopt($ch, CURLOPT_NOBODY, true); 
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
    curl_setopt($ch, CURLOPT_TIMEOUT, 10);  // Set timeout to 10 seconds
    $headers = curl_exec($ch);
    $info = curl_getinfo($ch);
    curl_close($ch);
    
    return $info;
}
```

Deze change vervangt de get_headers function met een curl variant. 