### PR TITLE
Fixed all usages of the config where an array is expected, but the de…

### DIFF
--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -60,7 +60,7 @@ class Plugin
 		$this->loadTextDomain();
 		$this->config->boot();
 
-		$dependencyChecker = new DependencyChecker($this->config->get('core.dependencies'));
+		$dependencyChecker = new DependencyChecker($this->config->get('core.dependencies', []));
 
 		if ($dependencyChecker->failed()) {
 			$dependencyChecker->notify();
@@ -148,7 +148,7 @@ class Plugin
 	public function callServiceProviders(string $method, string $key = ''): void
 	{
 		$offset = $key ? "core.providers.{$key}" : 'core.providers';
-		$services = (array) $this->config->get($offset);
+		$services = (array) $this->config->get($offset, []);
 
 		foreach ($services as $service) {
 			if (is_array($service)) {

--- a/src/Base/Metabox/MetaboxServiceProvider.php
+++ b/src/Base/Metabox/MetaboxServiceProvider.php
@@ -22,11 +22,11 @@ class MetaboxServiceProvider extends MetaboxBaseServiceProvider
 
     public function registerMetaboxes(array $rwmbMetaboxes): array
     {
-        $configMetaboxes = $this->plugin->config->get('metaboxes');
+        $configMetaboxes = $this->plugin->config->get('metaboxes', []);
         $configMetaboxes = $this->addOptionsUPL($configMetaboxes);
 
         if ($this->plugin->settings->useIdentifications()) {
-            $configMetaboxes = array_merge($configMetaboxes, $this->plugin->config->get('identifications_metaboxes'));
+            $configMetaboxes = array_merge($configMetaboxes, $this->plugin->config->get('identifications_metaboxes', []));
         }
 
         if ($this->plugin->settings->useIdentifications() && ! $this->plugin->settings->useCombinedIdentification()) {
@@ -34,7 +34,7 @@ class MetaboxServiceProvider extends MetaboxBaseServiceProvider
         }
 
         if ($this->plugin->settings->useEscapeElement()) {
-            $configMetaboxes = array_merge($configMetaboxes, $this->plugin->config->get('escape_element_metabox'));
+            $configMetaboxes = array_merge($configMetaboxes, $this->plugin->config->get('escape_element_metabox', []));
         }
 
         if ($this->plugin->settings->useShowOn()) {
@@ -83,22 +83,22 @@ class MetaboxServiceProvider extends MetaboxBaseServiceProvider
 
     protected function getShowOnMetabox(array $configMetaboxes): array
     {
-        return array_merge($configMetaboxes, $this->plugin->config->get('show_on_metabox'));
+        return array_merge($configMetaboxes, $this->plugin->config->get('show_on_metabox', []));
     }
 
 	protected function getTilesMetabox(array $configMetaboxes): array
     {
-        return array_merge($configMetaboxes, $this->plugin->config->get('theme_tiles_metabox'));
+        return array_merge($configMetaboxes, $this->plugin->config->get('theme_tiles_metabox', []));
     }
 
 	protected function getTableOfContentsMetabox(array $configMetaboxes): array
     {
-        return array_merge($configMetaboxes, $this->plugin->config->get('table_of_contents_metabox'));
+        return array_merge($configMetaboxes, $this->plugin->config->get('table_of_contents_metabox', []));
     }
 
     protected function getFeedbackFormMetabox(array $configMetaboxes): array
     {
-        $feedbackFormMetabox = $this->plugin->config->get('hide_feedback_form_metabox');
+        $feedbackFormMetabox = $this->plugin->config->get('hide_feedback_form_metabox', []);
         $metaboxKeys = ['base', 'pdc-category', 'pdc-subcategory'];
 
         return array_map(function ($key, $metabox) use ($metaboxKeys, $feedbackFormMetabox) {

--- a/src/Base/PostType/PostTypeServiceProvider.php
+++ b/src/Base/PostType/PostTypeServiceProvider.php
@@ -36,7 +36,7 @@ class PostTypeServiceProvider extends ServiceProvider
     public function registerPostTypes()
     {
         if (function_exists('register_extended_post_type')) {
-            $this->configPostTypes = $this->plugin->config->get('posttypes');
+            $this->configPostTypes = $this->plugin->config->get('posttypes', []);
 
             foreach ($this->configPostTypes as $postTypeName => $postType) {
                 if ('pdc-group' === $postTypeName && ! $this->plugin->settings->useGroupLayer()) {

--- a/src/Base/PostsToPosts/PostsToPostsServiceProvider.php
+++ b/src/Base/PostsToPosts/PostsToPostsServiceProvider.php
@@ -92,7 +92,7 @@ class PostsToPostsServiceProvider extends ServiceProvider
             ],
         ];
 
-        $this->plugin->config->set(['p2p_connections.connections' => array_merge($this->plugin->config->get('p2p_connections.connections'), $groupConnections)]);
+        $this->plugin->config->set(['p2p_connections.connections' => array_merge($this->plugin->config->get('p2p_connections.connections', []), $groupConnections)]);
     }
 
     /**
@@ -103,9 +103,9 @@ class PostsToPostsServiceProvider extends ServiceProvider
     public function registerPostsToPostsConnections(): void
     {
         if (function_exists('p2p_register_connection_type')) {
-            $posttypesInfo = $this->plugin->config->get('p2p_connections.posttypes_info');
+            $posttypesInfo = $this->plugin->config->get('p2p_connections.posttypes_info', []);
             $defaultConnectionArgs = apply_filters('owc/pdc-base/p2p-connection-defaults', $this->connectionDefaults);
-            $connections = $this->plugin->config->get('p2p_connections.connections');
+            $connections = $this->plugin->config->get('p2p_connections.connections', []);
 
             foreach ($connections as $connectionArgs) {
                 $args = array_merge($defaultConnectionArgs, $connectionArgs);

--- a/src/Base/RestAPI/ItemFields/ConnectedField.php
+++ b/src/Base/RestAPI/ItemFields/ConnectedField.php
@@ -40,7 +40,7 @@ class ConnectedField extends CreatesFields
      */
     public function create(WP_Post $post): array
     {
-        $connections = array_filter($this->plugin->config->get('p2p_connections.connections'), function ($connection) {
+        $connections = array_filter($this->plugin->config->get('p2p_connections.connections', []), function ($connection) {
             return in_array('pdc-item', $connection, true);
         });
 
@@ -158,14 +158,14 @@ class ConnectedField extends CreatesFields
     {
         $query = [];
 
-        $connectionsExcludeInActive = $this->plugin->config->get('p2p_connections.connections_exclude_inactive');
+        $connectionsExcludeInActive = $this->plugin->config->get('p2p_connections.connections_exclude_inactive', []);
 
         if (in_array($type, $connectionsExcludeInActive)) {
             $query = array_merge_recursive($query, $this->excludeInactiveItemsQuery());
         }
 
         if ($this->isPluginPDCInternalProductsActive()) {
-            $connectionsExcludeInternal = $this->plugin->config->get('p2p_connections.connections_exclude_internal');
+            $connectionsExcludeInternal = $this->plugin->config->get('p2p_connections.connections_exclude_internal', []);
 
             if (in_array($type, $connectionsExcludeInternal)) {
                 $query = array_merge_recursive($query, $this->excludeInternalItemsQuery());

--- a/src/Base/RestAPI/ItemFields/SeoPress.php
+++ b/src/Base/RestAPI/ItemFields/SeoPress.php
@@ -18,7 +18,7 @@ class SeoPress extends AbstractSEO
      */
     public function create(WP_Post $post): array
     {
-        $seoMetaFields = $this->plugin->config->get('seopress_api.meta');
+        $seoMetaFields = $this->plugin->config->get('seopress_api.meta', []);
 
         if (! is_array($seoMetaFields) || empty($seoMetaFields)) {
             return [];

--- a/src/Base/RestAPI/ItemFields/TaxonomyField.php
+++ b/src/Base/RestAPI/ItemFields/TaxonomyField.php
@@ -25,7 +25,7 @@ class TaxonomyField extends CreatesFields
     {
         $result = [];
 
-        foreach (array_keys($this->plugin->config->get('taxonomies')) as $taxonomy) {
+        foreach (array_keys($this->plugin->config->get('taxonomies', [])) as $taxonomy) {
             $result[$taxonomy] = $this->getTerms($post->ID, $taxonomy);
         }
 

--- a/src/Base/RestAPI/ItemFields/Yoast.php
+++ b/src/Base/RestAPI/ItemFields/Yoast.php
@@ -19,7 +19,7 @@ class Yoast extends AbstractSEO
      */
     public function create(WP_Post $post): array
     {
-        $seoMetaFields = $this->plugin->config->get('yoast_api.meta');
+        $seoMetaFields = $this->plugin->config->get('yoast_api.meta', []);
 
         if (! is_array($seoMetaFields) || empty($seoMetaFields)) {
             return [];

--- a/src/Base/RestAPI/RestAPIServiceProvider.php
+++ b/src/Base/RestAPI/RestAPIServiceProvider.php
@@ -183,7 +183,7 @@ class RestAPIServiceProvider extends ServiceProvider
     private function registerModelFields()
     {
         // Add global fields for all Models.
-        foreach ($this->plugin->config->get('api.models') as $posttype => $data) {
+        foreach ($this->plugin->config->get('api.models', []) as $posttype => $data) {
             foreach ($data['fields'] as $key => $creator) {
                 $class = '\OWC\PDC\Base\Repositories\\' . ucfirst($posttype);
                 if (class_exists($class)) {

--- a/src/Base/Settings/SettingsServiceProvider.php
+++ b/src/Base/Settings/SettingsServiceProvider.php
@@ -33,7 +33,7 @@ class SettingsServiceProvider extends MetaboxBaseServiceProvider
      */
     public function registerSettingsPage($rwmbSettingsPages)
     {
-        $settingsPages = $this->plugin->config->get('settings_pages');
+        $settingsPages = $this->plugin->config->get('settings_pages', []);
 
         return array_merge($rwmbSettingsPages, $settingsPages);
     }
@@ -47,7 +47,7 @@ class SettingsServiceProvider extends MetaboxBaseServiceProvider
      */
     public function registerSettings($rwmbMetaboxes)
     {
-        $configMetaboxes = $this->plugin->config->get('settings');
+        $configMetaboxes = $this->plugin->config->get('settings', []);
         $metaboxes = [];
 
         foreach ($configMetaboxes as $metabox) {

--- a/src/Base/Taxonomy/TaxonomyServiceProvider.php
+++ b/src/Base/Taxonomy/TaxonomyServiceProvider.php
@@ -70,10 +70,10 @@ class TaxonomyServiceProvider extends ServiceProvider
     protected function filterConfigTaxonomies(): array
     {
         if ($this->plugin->settings->useShowOn()) {
-            return $this->plugin->config->get('taxonomies');
+            return $this->plugin->config->get('taxonomies', []);
         }
 
-        return array_filter($this->plugin->config->get('taxonomies'), function ($taxonomyKey) {
+        return array_filter($this->plugin->config->get('taxonomies', []), function ($taxonomyKey) {
             return ('pdc-show-on' !== $taxonomyKey);
         }, ARRAY_FILTER_USE_KEY);
     }


### PR DESCRIPTION
Fixed all usages of the config where an array is expected, but the default from config::get is null. Set the default value to blank array.

It looks like these literally are all usages of config::get so the default default should be `[]`, but I don't want to make assumptions.