### PR TITLE
Make sure the correct portal url is used when filtering on source (i.…

### DIFF
--- a/src/Base/Models/PortalLinkGenerator.php
+++ b/src/Base/Models/PortalLinkGenerator.php
@@ -68,6 +68,14 @@ class PortalLinkGenerator
         }
 
         $portalURL = reset($terms);
+	    if (isset($_GET['source'])) {
+		    foreach( $terms as $term ) {
+			    if ($term->slug === $_GET['source']) {
+				    $portalURL = $term;
+				    break;
+			    }
+		    }
+	    }
         $portalURL = $portalURL instanceof WP_Term ? $portalURL->name : '';
 
         return wp_http_validate_url($portalURL) ? $portalURL : '/';


### PR DESCRIPTION
…e. through the REST API).