### PR TITLE
Allow sorting parameters, mainly to get PDC items sorted by name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_style = tab
 space_around_brackets = true
 indent_size = 4
 
+[*.php]
+indent_style = space
+
 [{.jshintrc,*.json,*.yml}]
 indent_style = space
 indent_size = 2

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -42,7 +42,7 @@ abstract class BaseController
             'data' => $data,
         ], [
             'pagination' => [
-                'total_count' => (int) $query->found_posts,
+                'total_count' => (int)$query->found_posts,
                 'total_pages' => $query->max_num_pages,
                 'current_page' => $page,
                 'limit' => $query->get('posts_per_page'),
@@ -68,7 +68,7 @@ abstract class BaseController
     {
         $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
 
-        if (! \is_user_logged_in()) {
+        if (!\is_user_logged_in()) {
             $preview = false;
         }
 
@@ -84,7 +84,7 @@ abstract class BaseController
             return false;
         }
 
-        if (! is_numeric($request->get_param('source'))) {
+        if (!is_numeric($request->get_param('source'))) {
             return false;
         }
 
@@ -112,38 +112,38 @@ abstract class BaseController
             return false;
         }
 
-        if (! is_array($request->get_param($param)) && ! is_string($request->get_param($param))) {
+        if (!is_array($request->get_param($param)) && !is_string($request->get_param($param))) {
             return false;
         }
 
         return true;
     }
 
-	protected function getOrderClause(mixed $orderBy, mixed $order)
-	{
-		$orderArray = [];
-		$orderByParts = explode(',', $orderBy);
-		$orderParts = explode(',', $order);
+    protected function getOrderClause(mixed $orderBy, mixed $order)
+    {
+        $orderArray = [];
+        $orderByParts = explode(',', $orderBy);
+        $orderParts = explode(',', $order);
 
-		// Empty string results in array with one empty value, we ignore that.
-		if (!array_filter($orderByParts)) {
-			return [];
-		}
+        // Empty string results in array with one empty value, we ignore that.
+        if (!array_filter($orderByParts)) {
+            return [];
+        }
 
-		// Single orderby value, return simple array.
-		if (count($orderByParts) === 1) {
-			return [
-				'orderby' => trim($orderByParts[0]),
-				'order' => strtoupper(trim($orderParts[0] ?? 'ASC')),
-			];
-		}
+        // Single orderby value, return simple array.
+        if (count($orderByParts) === 1) {
+            return [
+                'orderby' => trim($orderByParts[0]),
+                'order' => strtoupper(trim($orderParts[0] ?? 'ASC')),
+            ];
+        }
 
-		// Multiple orderby values, return associative array.
-		foreach ($orderByParts as $index => $orderByPart) {
-			$orderValue = $orderParts[$index] ?? $orderParts[0] ?? 'ASC';
-			$orderArray[trim($orderByPart)] = strtoupper(trim($orderValue));
-		}
+        // Multiple orderby values, return associative array.
+        foreach ($orderByParts as $index => $orderByPart) {
+            $orderValue = $orderParts[$index] ?? $orderParts[0] ?? 'ASC';
+            $orderArray[trim($orderByPart)] = strtoupper(trim($orderValue));
+        }
 
-		return ['orderby' => $orderArray];
-	}
+        return ['orderby' => $orderArray];
+    }
 }

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -6,9 +6,9 @@
 
 namespace OWC\PDC\Base\RestAPI\Controllers;
 
+use OWC\PDC\Base\Foundation\Plugin;
 use WP_Query;
 use WP_REST_Request;
-use OWC\PDC\Base\Foundation\Plugin;
 
 /**
  * Controller which handels general quering, such as pagination.
@@ -119,14 +119,14 @@ abstract class BaseController
         return true;
     }
 
-    protected function getOrderClause(mixed $orderBy, mixed $order)
+    protected function getOrderClause(string $orderBy, string $order): array
     {
         $orderArray = [];
         $orderByParts = explode(',', $orderBy);
         $orderParts = explode(',', $order);
 
         // Empty string results in array with one empty value, we ignore that.
-        if (!array_filter($orderByParts)) {
+        if (! array_filter($orderByParts)) {
             return [];
         }
 

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -118,4 +118,32 @@ abstract class BaseController
 
         return true;
     }
+
+	protected function getOrderClause(mixed $orderBy, mixed $order)
+	{
+		$orderArray = [];
+		$orderByParts = explode(',', $orderBy);
+		$orderParts = explode(',', $order);
+
+		// Empty string results in array with one empty value, we ignore that.
+		if (!array_filter($orderByParts)) {
+			return [];
+		}
+
+		// Single orderby value, return simple array.
+		if (count($orderByParts) === 1) {
+			return [
+				'orderby' => trim($orderByParts[0]),
+				'order' => strtoupper(trim($orderParts[0] ?? 'ASC')),
+			];
+		}
+
+		// Multiple orderby values, return associative array.
+		foreach ($orderByParts as $index => $orderByPart) {
+			$orderValue = $orderParts[$index] ?? $orderParts[0] ?? 'ASC';
+			$orderArray[trim($orderByPart)] = strtoupper(trim($orderValue));
+		}
+
+		return ['orderby' => $orderArray];
+	}
 }

--- a/src/Base/RestAPI/Controllers/BaseController.php
+++ b/src/Base/RestAPI/Controllers/BaseController.php
@@ -42,7 +42,7 @@ abstract class BaseController
             'data' => $data,
         ], [
             'pagination' => [
-                'total_count' => (int)$query->found_posts,
+                'total_count' => (int) $query->found_posts,
                 'total_pages' => $query->max_num_pages,
                 'current_page' => $page,
                 'limit' => $query->get('posts_per_page'),
@@ -68,7 +68,7 @@ abstract class BaseController
     {
         $preview = filter_var($request->get_param('draft-preview'), FILTER_VALIDATE_BOOLEAN);
 
-        if (!\is_user_logged_in()) {
+        if (! \is_user_logged_in()) {
             $preview = false;
         }
 
@@ -84,7 +84,7 @@ abstract class BaseController
             return false;
         }
 
-        if (!is_numeric($request->get_param('source'))) {
+        if (! is_numeric($request->get_param('source'))) {
             return false;
         }
 
@@ -112,7 +112,7 @@ abstract class BaseController
             return false;
         }
 
-        if (!is_array($request->get_param($param)) && !is_string($request->get_param($param))) {
+        if (! is_array($request->get_param($param)) && ! is_string($request->get_param($param))) {
             return false;
         }
 

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -18,181 +18,181 @@ use OWC\PDC\Base\Support\Traits\CheckPluginActive;
 class ItemController extends BaseController
 {
     use CheckPluginActive;
-	use QueryHelpers;
+    use QueryHelpers;
 
-	/**
-	 * Get a list of all items.
-	 */
-	public function getItems(WP_REST_Request $request): array
-	{
-		$orderBy = $request->get_param('orderby') ?? 'post_date,ID';
-		$order = $request->get_param('order') ?? 'DESC,DESC';
+    /**
+     * Get a list of all items.
+     */
+    public function getItems(WP_REST_Request $request): array
+    {
+        $orderBy = $request->get_param('orderby') ?? 'post_date,ID';
+        $order = $request->get_param('order') ?? 'DESC,DESC';
 
-		$parameters = $this->convertParameters($request->get_params());
-		$items = (new Item())
-			->query(apply_filters('owc/pdc/rest-api/items/query', $this->getPaginatorParams($request)))
-			->query($parameters)
-			->query($this->excludeInactiveItemsQuery())
-			->query($this->getOrderClause($orderBy, $order));
+        $parameters = $this->convertParameters($request->get_params());
+        $items = (new Item())
+            ->query(apply_filters('owc/pdc/rest-api/items/query', $this->getPaginatorParams($request)))
+            ->query($parameters)
+            ->query($this->excludeInactiveItemsQuery())
+            ->query($this->getOrderClause($orderBy, $order));
 
-		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-			$items->filterSource($request->get_param('source'));
-		};
+        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+            $items->filterSource($request->get_param('source'));
+        };
 
-		if ($this->targetAudienceParamIsValid($request)) {
-			$items->filterTargetAudience($request->get_param('pdc-doelgroep'));
-		}
+        if ($this->targetAudienceParamIsValid($request)) {
+            $items->filterTargetAudience($request->get_param('pdc-doelgroep'));
+        }
 
-		if ($this->aspectParamIsValid($request)) {
-			$items->filterAspect($request->get_param('pdc-aspect'));
-		}
+        if ($this->aspectParamIsValid($request)) {
+            $items->filterAspect($request->get_param('pdc-aspect'));
+        }
 
-		if ($this->usageParamIsValid($request)) {
-			$items->filterUsage($request->get_param('pdc-usage'));
-		}
+        if ($this->usageParamIsValid($request)) {
+            $items->filterUsage($request->get_param('pdc-usage'));
+        }
 
-		if (false === $parameters['include-connected']) {
-			$items->hide(['connected']);
-		}
+        if (false === $parameters['include-connected']) {
+            $items->hide(['connected']);
+        }
 
-		$data = $items->all();
-		$query = $items->getQuery();
+        $data = $items->all();
+        $query = $items->getQuery();
 
-		return $this->addPaginator($data, $query);
-	}
+        return $this->addPaginator($data, $query);
+    }
 
-	/**
-	 * Convert the parameters to the allowed ones.
-	 */
-	protected function convertParameters(array $parametersFromRequest): array
-	{
-		$parameters = [];
+    /**
+     * Convert the parameters to the allowed ones.
+     */
+    protected function convertParameters(array $parametersFromRequest): array
+    {
+        $parameters = [];
 
-		if (isset($parametersFromRequest['name'])) {
-			$parameters['name'] = esc_attr($parametersFromRequest['name']);
-		}
+        if (isset($parametersFromRequest['name'])) {
+            $parameters['name'] = esc_attr($parametersFromRequest['name']);
+        }
 
-		$parameters['include-connected'] = (isset($parametersFromRequest['include-connected'])) ? true : false;
+        $parameters['include-connected'] = (isset($parametersFromRequest['include-connected'])) ? true : false;
 
-		if (isset($parametersFromRequest['slug'])) {
-			$parameters['name'] = esc_attr($parametersFromRequest['slug']);
-			unset($parametersFromRequest['slug']);
-		}
+        if (isset($parametersFromRequest['slug'])) {
+            $parameters['name'] = esc_attr($parametersFromRequest['slug']);
+            unset($parametersFromRequest['slug']);
+        }
 
-		if (isset($parametersFromRequest['id'])) {
-			$parameters['p'] = absint($parametersFromRequest['id']);
-			unset($parametersFromRequest['slug']);
-		}
+        if (isset($parametersFromRequest['id'])) {
+            $parameters['p'] = absint($parametersFromRequest['id']);
+            unset($parametersFromRequest['slug']);
+        }
 
-		return $parameters;
-	}
+        return $parameters;
+    }
 
-	/**
-	 * Get an individual post item.
-	 *
-	 * @return array|WP_Error
-	 */
-	public function getItem(WP_REST_Request $request)
-	{
-		$id = (int)$request->get_param('id');
-		$item = $this->buildQueryFromRequest($request);
+    /**
+     * Get an individual post item.
+     *
+     * @return array|WP_Error
+     */
+    public function getItem(WP_REST_Request $request)
+    {
+        $id = (int)$request->get_param('id');
+        $item = $this->buildQueryFromRequest($request);
 
-		$item = $item->find($id);
+        $item = $item->find($id);
 
-		if (!$item) {
-			return new WP_Error('no_item_found', sprintf('Item with ID [%d] not found', $id), [
-				'status' => 404,
-			]);
-		}
+        if (!$item) {
+            return new WP_Error('no_item_found', sprintf('Item with ID [%d] not found', $id), [
+                'status' => 404,
+            ]);
+        }
 
-		if ($this->needsAuthorization($item)) {
-			return new WP_Error(
-				'unauthorized_request',
-				sprintf('Unauthorized request for item with ID [%d]', $id),
-				['status' => 401]
-			);
-		}
+        if ($this->needsAuthorization($item)) {
+            return new WP_Error(
+                'unauthorized_request',
+                sprintf('Unauthorized request for item with ID [%d]', $id),
+                ['status' => 401]
+            );
+        }
 
-		return $item;
-	}
+        return $item;
+    }
 
-	/**
-	 * Get an individual post item by slug.
-	 *
-	 * @return array|WP_Error
-	 */
-	public function getItemBySlug(WP_REST_Request $request)
-	{
-		$slug = $request->get_param('slug');
-		$item = $this->buildQueryFromRequest($request);
+    /**
+     * Get an individual post item by slug.
+     *
+     * @return array|WP_Error
+     */
+    public function getItemBySlug(WP_REST_Request $request)
+    {
+        $slug = $request->get_param('slug');
+        $item = $this->buildQueryFromRequest($request);
 
-		$item = $item->findBySlug($slug);
+        $item = $item->findBySlug($slug);
 
-		if (!$item) {
-			return new WP_Error(
-				'no_item_found',
-				sprintf('Item with slug [%s] not found', $slug),
-				['status' => 404]
-			);
-		}
+        if (!$item) {
+            return new WP_Error(
+                'no_item_found',
+                sprintf('Item with slug [%s] not found', $slug),
+                ['status' => 404]
+            );
+        }
 
-		if ($this->needsAuthorization($item)) {
-			return new WP_Error(
-				'unauthorized_request',
-				sprintf('Unauthorized request for item with slug [%s]', $slug),
-				['status' => 401]
-			);
-		}
+        if ($this->needsAuthorization($item)) {
+            return new WP_Error(
+                'unauthorized_request',
+                sprintf('Unauthorized request for item with slug [%s]', $slug),
+                ['status' => 401]
+            );
+        }
 
-		return $item;
-	}
+        return $item;
+    }
 
-	public function buildQueryFromRequest(WP_REST_Request $request): Item
-	{
-		$item = (new Item())
-			->query(apply_filters('owc/pdc/rest-api/items/query/single', []))
-			->query(['post_status' => $this->getPostStatus($request)])
-			->query($this->excludeInactiveItemsQuery());
+    public function buildQueryFromRequest(WP_REST_Request $request): Item
+    {
+        $item = (new Item())
+            ->query(apply_filters('owc/pdc/rest-api/items/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)])
+            ->query($this->excludeInactiveItemsQuery());
 
-		$password = esc_attr($request->get_param('password'));
-		if (!empty($password)) {
-			$item->setPassword($password);
-		}
+        $password = esc_attr($request->get_param('password'));
+        if (!empty($password)) {
+            $item->setPassword($password);
+        }
 
-		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-			$item->filterSource($request->get_param('source'));
-		};
+        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+            $item->filterSource($request->get_param('source'));
+        };
 
-		$connectedField = $item->getGlobalField('connected');
-		if ($request->get_param('connected_sort') && !empty($connectedField)) {
-			$connectedField['creator']->setSorting(
-				$request->get_param('connected_sort'),
-				strtoupper($request->get_param('connected_sort_direction')) ?: 'ASC',
-				$request->get_param('connected_sort_type') ?: 'string'
-			);
-		}
+        $connectedField = $item->getGlobalField('connected');
+        if ($request->get_param('connected_sort') && !empty($connectedField)) {
+            $connectedField['creator']->setSorting(
+                $request->get_param('connected_sort'),
+                strtoupper($request->get_param('connected_sort_direction')) ?: 'ASC',
+                $request->get_param('connected_sort_type') ?: 'string'
+            );
+        }
 
-		return $item;
-	}
+        return $item;
+    }
 
-	private function needsAuthorization(array $item): bool
-	{
-		if (!$this->isPluginPDCInternalProductsActive()) {
-			return false;
-		}
+    private function needsAuthorization(array $item): bool
+    {
+        if (!$this->isPluginPDCInternalProductsActive()) {
+            return false;
+        }
 
-		$types = $item['taxonomies']['pdc-type'] ?? [];
+        $types = $item['taxonomies']['pdc-type'] ?? [];
 
-		if (empty($types)) {
-			return false;
-		}
+        if (empty($types)) {
+            return false;
+        }
 
-		foreach ($types as $type) {
-			if ('external' === $type['slug']) {
-				return false;
-			}
-		}
+        foreach ($types as $type) {
+            if ('external' === $type['slug']) {
+                return false;
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -17,182 +17,182 @@ use OWC\PDC\Base\Support\Traits\CheckPluginActive;
  */
 class ItemController extends BaseController
 {
-    use CheckPluginActive;
-    use QueryHelpers;
+	use CheckPluginActive;
+	use QueryHelpers;
 
-    /**
-     * Get a list of all items.
-     */
-    public function getItems(WP_REST_Request $request): array
-    {
-        $parameters = $this->convertParameters($request->get_params());
-        $items = (new Item())
-            ->query(apply_filters('owc/pdc/rest-api/items/query', $this->getPaginatorParams($request)))
-            ->query($parameters)
-            ->query($this->excludeInactiveItemsQuery())
-            ->query(['orderby' => [
-                'post_date' => 'DESC',
-                'ID' => 'DESC',
-            ]]);
+	/**
+	 * Get a list of all items.
+	 */
+	public function getItems(WP_REST_Request $request): array
+	{
+		$orderBy = $request->get_param('orderby') ?? 'post_date,ID';
+		$order = $request->get_param('order') ?? 'DESC,DESC';
 
-        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-            $items->filterSource($request->get_param('source'));
-        };
+		$parameters = $this->convertParameters($request->get_params());
+		$items = (new Item())
+			->query(apply_filters('owc/pdc/rest-api/items/query', $this->getPaginatorParams($request)))
+			->query($parameters)
+			->query($this->excludeInactiveItemsQuery())
+			->query($this->getOrderClause($orderBy, $order));
 
-        if ($this->targetAudienceParamIsValid($request)) {
-            $items->filterTargetAudience($request->get_param('pdc-doelgroep'));
-        }
+		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+			$items->filterSource($request->get_param('source'));
+		};
 
-        if ($this->aspectParamIsValid($request)) {
-            $items->filterAspect($request->get_param('pdc-aspect'));
-        }
+		if ($this->targetAudienceParamIsValid($request)) {
+			$items->filterTargetAudience($request->get_param('pdc-doelgroep'));
+		}
 
-        if ($this->usageParamIsValid($request)) {
-            $items->filterUsage($request->get_param('pdc-usage'));
-        }
+		if ($this->aspectParamIsValid($request)) {
+			$items->filterAspect($request->get_param('pdc-aspect'));
+		}
 
-        if (false === $parameters['include-connected']) {
-            $items->hide(['connected']);
-        }
+		if ($this->usageParamIsValid($request)) {
+			$items->filterUsage($request->get_param('pdc-usage'));
+		}
 
-        $data = $items->all();
-        $query = $items->getQuery();
+		if (false === $parameters['include-connected']) {
+			$items->hide(['connected']);
+		}
 
-        return $this->addPaginator($data, $query);
-    }
+		$data = $items->all();
+		$query = $items->getQuery();
 
-    /**
-     * Convert the parameters to the allowed ones.
-     */
-    protected function convertParameters(array $parametersFromRequest): array
-    {
-        $parameters = [];
+		return $this->addPaginator($data, $query);
+	}
 
-        if (isset($parametersFromRequest['name'])) {
-            $parameters['name'] = esc_attr($parametersFromRequest['name']);
-        }
+	/**
+	 * Convert the parameters to the allowed ones.
+	 */
+	protected function convertParameters(array $parametersFromRequest): array
+	{
+		$parameters = [];
 
-        $parameters['include-connected'] = (isset($parametersFromRequest['include-connected'])) ? true : false;
+		if (isset($parametersFromRequest['name'])) {
+			$parameters['name'] = esc_attr($parametersFromRequest['name']);
+		}
 
-        if (isset($parametersFromRequest['slug'])) {
-            $parameters['name'] = esc_attr($parametersFromRequest['slug']);
-            unset($parametersFromRequest['slug']);
-        }
+		$parameters['include-connected'] = (isset($parametersFromRequest['include-connected'])) ? true : false;
 
-        if (isset($parametersFromRequest['id'])) {
-            $parameters['p'] = absint($parametersFromRequest['id']);
-            unset($parametersFromRequest['slug']);
-        }
+		if (isset($parametersFromRequest['slug'])) {
+			$parameters['name'] = esc_attr($parametersFromRequest['slug']);
+			unset($parametersFromRequest['slug']);
+		}
 
-        return $parameters;
-    }
+		if (isset($parametersFromRequest['id'])) {
+			$parameters['p'] = absint($parametersFromRequest['id']);
+			unset($parametersFromRequest['slug']);
+		}
 
-    /**
-     * Get an individual post item.
-     *
-     * @return array|WP_Error
-     */
-    public function getItem(WP_REST_Request $request)
-    {
-        $id = (int) $request->get_param('id');
-        $item = $this->buildQueryFromRequest($request);
+		return $parameters;
+	}
 
-        $item = $item->find($id);
+	/**
+	 * Get an individual post item.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function getItem(WP_REST_Request $request)
+	{
+		$id = (int)$request->get_param('id');
+		$item = $this->buildQueryFromRequest($request);
 
-        if (! $item) {
-            return new WP_Error('no_item_found', sprintf('Item with ID [%d] not found', $id), [
-                'status' => 404,
-            ]);
-        }
+		$item = $item->find($id);
 
-        if ($this->needsAuthorization($item)) {
-            return new WP_Error(
-                'unauthorized_request',
-                sprintf('Unauthorized request for item with ID [%d]', $id),
-                ['status' => 401]
-            );
-        }
+		if (!$item) {
+			return new WP_Error('no_item_found', sprintf('Item with ID [%d] not found', $id), [
+				'status' => 404,
+			]);
+		}
 
-        return $item;
-    }
+		if ($this->needsAuthorization($item)) {
+			return new WP_Error(
+				'unauthorized_request',
+				sprintf('Unauthorized request for item with ID [%d]', $id),
+				['status' => 401]
+			);
+		}
 
-    /**
-     * Get an individual post item by slug.
-     *
-     * @return array|WP_Error
-     */
-    public function getItemBySlug(WP_REST_Request $request)
-    {
-        $slug = $request->get_param('slug');
-        $item = $this->buildQueryFromRequest($request);
+		return $item;
+	}
 
-        $item = $item->findBySlug($slug);
+	/**
+	 * Get an individual post item by slug.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function getItemBySlug(WP_REST_Request $request)
+	{
+		$slug = $request->get_param('slug');
+		$item = $this->buildQueryFromRequest($request);
 
-        if (! $item) {
-            return new WP_Error(
-                'no_item_found',
-                sprintf('Item with slug [%s] not found', $slug),
-                ['status' => 404]
-            );
-        }
+		$item = $item->findBySlug($slug);
 
-        if ($this->needsAuthorization($item)) {
-            return new WP_Error(
-                'unauthorized_request',
-                sprintf('Unauthorized request for item with slug [%s]', $slug),
-                ['status' => 401]
-            );
-        }
+		if (!$item) {
+			return new WP_Error(
+				'no_item_found',
+				sprintf('Item with slug [%s] not found', $slug),
+				['status' => 404]
+			);
+		}
 
-        return $item;
-    }
+		if ($this->needsAuthorization($item)) {
+			return new WP_Error(
+				'unauthorized_request',
+				sprintf('Unauthorized request for item with slug [%s]', $slug),
+				['status' => 401]
+			);
+		}
 
-    public function buildQueryFromRequest(WP_REST_Request $request): Item
-    {
-        $item = (new Item())
-            ->query(apply_filters('owc/pdc/rest-api/items/query/single', []))
-            ->query(['post_status' => $this->getPostStatus($request)])
-            ->query($this->excludeInactiveItemsQuery());
+		return $item;
+	}
 
-        $password = esc_attr($request->get_param('password'));
-        if (! empty($password)) {
-            $item->setPassword($password);
-        }
+	public function buildQueryFromRequest(WP_REST_Request $request): Item
+	{
+		$item = (new Item())
+			->query(apply_filters('owc/pdc/rest-api/items/query/single', []))
+			->query(['post_status' => $this->getPostStatus($request)])
+			->query($this->excludeInactiveItemsQuery());
 
-        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-            $item->filterSource($request->get_param('source'));
-        };
+		$password = esc_attr($request->get_param('password'));
+		if (!empty($password)) {
+			$item->setPassword($password);
+		}
 
-        $connectedField = $item->getGlobalField('connected');
-        if ($request->get_param('connected_sort') && ! empty($connectedField)) {
-            $connectedField['creator']->setSorting(
-                $request->get_param('connected_sort'),
-                strtoupper($request->get_param('connected_sort_direction')) ?: 'ASC',
-                $request->get_param('connected_sort_type') ?: 'string'
-            );
-        }
+		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+			$item->filterSource($request->get_param('source'));
+		};
 
-        return $item;
-    }
+		$connectedField = $item->getGlobalField('connected');
+		if ($request->get_param('connected_sort') && !empty($connectedField)) {
+			$connectedField['creator']->setSorting(
+				$request->get_param('connected_sort'),
+				strtoupper($request->get_param('connected_sort_direction')) ?: 'ASC',
+				$request->get_param('connected_sort_type') ?: 'string'
+			);
+		}
 
-    private function needsAuthorization(array $item): bool
-    {
-        if (! $this->isPluginPDCInternalProductsActive()) {
-            return false;
-        }
+		return $item;
+	}
 
-        $types = $item['taxonomies']['pdc-type'] ?? [];
+	private function needsAuthorization(array $item): bool
+	{
+		if (!$this->isPluginPDCInternalProductsActive()) {
+			return false;
+		}
 
-        if (empty($types)) {
-            return false;
-        }
+		$types = $item['taxonomies']['pdc-type'] ?? [];
 
-        foreach ($types as $type) {
-            if ('external' === $type['slug']) {
-                return false;
-            }
-        }
+		if (empty($types)) {
+			return false;
+		}
 
-        return true;
-    }
+		foreach ($types as $type) {
+			if ('external' === $type['slug']) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 }

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -17,7 +17,7 @@ use OWC\PDC\Base\Support\Traits\CheckPluginActive;
  */
 class ItemController extends BaseController
 {
-	use CheckPluginActive;
+    use CheckPluginActive;
 	use QueryHelpers;
 
 	/**

--- a/src/Base/RestAPI/Controllers/ItemController.php
+++ b/src/Base/RestAPI/Controllers/ItemController.php
@@ -94,12 +94,12 @@ class ItemController extends BaseController
      */
     public function getItem(WP_REST_Request $request)
     {
-        $id = (int)$request->get_param('id');
+        $id = (int) $request->get_param('id');
         $item = $this->buildQueryFromRequest($request);
 
         $item = $item->find($id);
 
-        if (!$item) {
+        if (! $item) {
             return new WP_Error('no_item_found', sprintf('Item with ID [%d] not found', $id), [
                 'status' => 404,
             ]);
@@ -128,7 +128,7 @@ class ItemController extends BaseController
 
         $item = $item->findBySlug($slug);
 
-        if (!$item) {
+        if (! $item) {
             return new WP_Error(
                 'no_item_found',
                 sprintf('Item with slug [%s] not found', $slug),
@@ -155,7 +155,7 @@ class ItemController extends BaseController
             ->query($this->excludeInactiveItemsQuery());
 
         $password = esc_attr($request->get_param('password'));
-        if (!empty($password)) {
+        if (! empty($password)) {
             $item->setPassword($password);
         }
 
@@ -164,7 +164,7 @@ class ItemController extends BaseController
         };
 
         $connectedField = $item->getGlobalField('connected');
-        if ($request->get_param('connected_sort') && !empty($connectedField)) {
+        if ($request->get_param('connected_sort') && ! empty($connectedField)) {
             $connectedField['creator']->setSorting(
                 $request->get_param('connected_sort'),
                 strtoupper($request->get_param('connected_sort_direction')) ?: 'ASC',
@@ -177,7 +177,7 @@ class ItemController extends BaseController
 
     private function needsAuthorization(array $item): bool
     {
-        if (!$this->isPluginPDCInternalProductsActive()) {
+        if (! $this->isPluginPDCInternalProductsActive()) {
             return false;
         }
 

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -15,96 +15,98 @@ use OWC\PDC\Base\Repositories\Subthema;
  */
 class SubthemaController extends BaseController
 {
-    /**
-     * Get a list of all subthemas.
-     */
-    public function getSubthemas(WP_REST_Request $request): array
-    {
-        $items = (new Subthema())
-            ->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
-            ->query([
-                'order' => 'ASC',
-                'orderby' => 'name',
-                'post_status' => $this->getPostStatus($request)
-            ]);
+	/**
+	 * Get a list of all subthemas.
+	 */
+	public function getSubthemas(WP_REST_Request $request): array
+	{
+		$orderBy = $request->get_param('orderby') ?? 'name';
+		$order = $request->get_param('order') ?? 'ASC';
 
-        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-            $items->filterSource($request->get_param('source'));
-        }
+		$items = (new Subthema())
+			->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
+			->query($this->getOrderClause($orderBy, $order))
+			->query([
+				'post_status' => $this->getPostStatus($request)
+			]);
 
-        if ($language = $request->get_param('language')) {
-            $items->filterLanguage((string) $language);
-        }
+		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+			$items->filterSource($request->get_param('source'));
+		}
 
-        $data = $items->all();
-        $query = $items->getQuery();
+		if ($language = $request->get_param('language')) {
+			$items->filterLanguage((string)$language);
+		}
 
-        return $this->addPaginator($data, $query);
-    }
+		$data = $items->all();
+		$query = $items->getQuery();
 
-    /**
-     * Get an individual subthema.
-     *
-     * @return array|WP_Error
-     */
-    public function getSubthema(WP_REST_Request $request)
-    {
-        $id = (int) $request->get_param('id');
+		return $this->addPaginator($data, $query);
+	}
 
-        $thema = (new Subthema())
-            ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
-            ->query(['post_status' => $this->getPostStatus($request)]);
+	/**
+	 * Get an individual subthema.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function getSubthema(WP_REST_Request $request)
+	{
+		$id = (int)$request->get_param('id');
 
-        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-            $thema->filterSource($request->get_param('source'));
-        }
+		$thema = (new Subthema())
+			->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+			->query(['post_status' => $this->getPostStatus($request)]);
 
-        if ($language = $request->get_param('language')) {
-            $thema->filterLanguage((string) $language);
-        }
+		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+			$thema->filterSource($request->get_param('source'));
+		}
 
-        $thema = $thema->find($id);
+		if ($language = $request->get_param('language')) {
+			$thema->filterLanguage((string)$language);
+		}
 
-        if (! $thema) {
-            return new WP_Error('no_item_found', sprintf('Subthema with ID [%d] not found', $id), [
-                'status' => 404,
-            ]);
-        }
+		$thema = $thema->find($id);
 
-        return $thema;
-    }
+		if (!$thema) {
+			return new WP_Error('no_item_found', sprintf('Subthema with ID [%d] not found', $id), [
+				'status' => 404,
+			]);
+		}
 
-    /**
-     * Get an individual subtheme by slug.
-     *
-     * @return array|WP_Error
-     */
-    public function getSubthemeBySlug(WP_REST_Request $request)
-    {
-        $slug = $request->get_param('slug');
+		return $thema;
+	}
 
-        $subtheme = (new Subthema())
-            ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
-            ->query(['post_status' => $this->getPostStatus($request)]);
+	/**
+	 * Get an individual subtheme by slug.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function getSubthemeBySlug(WP_REST_Request $request)
+	{
+		$slug = $request->get_param('slug');
 
-        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-            $subtheme->filterSource($request->get_param('source'));
-        }
+		$subtheme = (new Subthema())
+			->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+			->query(['post_status' => $this->getPostStatus($request)]);
 
-        if ($language = $request->get_param('language')) {
-            $subtheme->filterLanguage((string) $language);
-        }
+		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+			$subtheme->filterSource($request->get_param('source'));
+		}
 
-        $subtheme = $subtheme->findBySlug($slug);
+		if ($language = $request->get_param('language')) {
+			$subtheme->filterLanguage((string)$language);
+		}
 
-        if (! $subtheme) {
-            return new WP_Error(
-                'no_subtheme_found',
-                sprintf('Subheme with slug [%s] not found', $slug),
-                ['status' => 404]
-            );
-        }
+		$subtheme = $subtheme->findBySlug($slug);
 
-        return $subtheme;
-    }
+		if (!$subtheme) {
+			return new WP_Error(
+				'no_subtheme_found',
+				sprintf('Subheme with slug [%s] not found', $slug),
+				['status' => 404]
+			);
+		}
+
+		return $subtheme;
+	}
 }

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -15,98 +15,98 @@ use OWC\PDC\Base\Repositories\Subthema;
  */
 class SubthemaController extends BaseController
 {
-	/**
-	 * Get a list of all subthemas.
-	 */
-	public function getSubthemas(WP_REST_Request $request): array
-	{
-		$orderBy = $request->get_param('orderby') ?? 'name';
-		$order = $request->get_param('order') ?? 'ASC';
+    /**
+     * Get a list of all subthemas.
+     */
+    public function getSubthemas(WP_REST_Request $request): array
+    {
+        $orderBy = $request->get_param('orderby') ?? 'name';
+        $order = $request->get_param('order') ?? 'ASC';
 
-		$items = (new Subthema())
-			->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
-			->query($this->getOrderClause($orderBy, $order))
-			->query([
-				'post_status' => $this->getPostStatus($request)
-			]);
+        $items = (new Subthema())
+            ->query(apply_filters('owc/pdc/rest-api/subthemas/query', $this->getPaginatorParams($request)))
+            ->query($this->getOrderClause($orderBy, $order))
+            ->query([
+                'post_status' => $this->getPostStatus($request)
+            ]);
 
-		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-			$items->filterSource($request->get_param('source'));
-		}
+        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+            $items->filterSource($request->get_param('source'));
+        }
 
-		if ($language = $request->get_param('language')) {
-			$items->filterLanguage((string)$language);
-		}
+        if ($language = $request->get_param('language')) {
+            $items->filterLanguage((string)$language);
+        }
 
-		$data = $items->all();
-		$query = $items->getQuery();
+        $data = $items->all();
+        $query = $items->getQuery();
 
-		return $this->addPaginator($data, $query);
-	}
+        return $this->addPaginator($data, $query);
+    }
 
-	/**
-	 * Get an individual subthema.
-	 *
-	 * @return array|WP_Error
-	 */
-	public function getSubthema(WP_REST_Request $request)
-	{
-		$id = (int)$request->get_param('id');
+    /**
+     * Get an individual subthema.
+     *
+     * @return array|WP_Error
+     */
+    public function getSubthema(WP_REST_Request $request)
+    {
+        $id = (int)$request->get_param('id');
 
-		$thema = (new Subthema())
-			->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
-			->query(['post_status' => $this->getPostStatus($request)]);
+        $thema = (new Subthema())
+            ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)]);
 
-		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-			$thema->filterSource($request->get_param('source'));
-		}
+        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+            $thema->filterSource($request->get_param('source'));
+        }
 
-		if ($language = $request->get_param('language')) {
-			$thema->filterLanguage((string)$language);
-		}
+        if ($language = $request->get_param('language')) {
+            $thema->filterLanguage((string)$language);
+        }
 
-		$thema = $thema->find($id);
+        $thema = $thema->find($id);
 
-		if (!$thema) {
-			return new WP_Error('no_item_found', sprintf('Subthema with ID [%d] not found', $id), [
-				'status' => 404,
-			]);
-		}
+        if (!$thema) {
+            return new WP_Error('no_item_found', sprintf('Subthema with ID [%d] not found', $id), [
+                'status' => 404,
+            ]);
+        }
 
-		return $thema;
-	}
+        return $thema;
+    }
 
-	/**
-	 * Get an individual subtheme by slug.
-	 *
-	 * @return array|WP_Error
-	 */
-	public function getSubthemeBySlug(WP_REST_Request $request)
-	{
-		$slug = $request->get_param('slug');
+    /**
+     * Get an individual subtheme by slug.
+     *
+     * @return array|WP_Error
+     */
+    public function getSubthemeBySlug(WP_REST_Request $request)
+    {
+        $slug = $request->get_param('slug');
 
-		$subtheme = (new Subthema())
-			->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
-			->query(['post_status' => $this->getPostStatus($request)]);
+        $subtheme = (new Subthema())
+            ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
+            ->query(['post_status' => $this->getPostStatus($request)]);
 
-		if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
-			$subtheme->filterSource($request->get_param('source'));
-		}
+        if ($this->plugin->settings->useShowOn() && $this->showOnParamIsValid($request)) {
+            $subtheme->filterSource($request->get_param('source'));
+        }
 
-		if ($language = $request->get_param('language')) {
-			$subtheme->filterLanguage((string)$language);
-		}
+        if ($language = $request->get_param('language')) {
+            $subtheme->filterLanguage((string)$language);
+        }
 
-		$subtheme = $subtheme->findBySlug($slug);
+        $subtheme = $subtheme->findBySlug($slug);
 
-		if (!$subtheme) {
-			return new WP_Error(
-				'no_subtheme_found',
-				sprintf('Subheme with slug [%s] not found', $slug),
-				['status' => 404]
-			);
-		}
+        if (!$subtheme) {
+            return new WP_Error(
+                'no_subtheme_found',
+                sprintf('Subheme with slug [%s] not found', $slug),
+                ['status' => 404]
+            );
+        }
 
-		return $subtheme;
-	}
+        return $subtheme;
+    }
 }

--- a/src/Base/RestAPI/Controllers/SubthemaController.php
+++ b/src/Base/RestAPI/Controllers/SubthemaController.php
@@ -35,7 +35,7 @@ class SubthemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $items->filterLanguage((string)$language);
+            $items->filterLanguage((string) $language);
         }
 
         $data = $items->all();
@@ -51,7 +51,7 @@ class SubthemaController extends BaseController
      */
     public function getSubthema(WP_REST_Request $request)
     {
-        $id = (int)$request->get_param('id');
+        $id = (int) $request->get_param('id');
 
         $thema = (new Subthema())
             ->query(apply_filters('owc/pdc/rest-api/subthemas/query/single', []))
@@ -62,12 +62,12 @@ class SubthemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $thema->filterLanguage((string)$language);
+            $thema->filterLanguage((string) $language);
         }
 
         $thema = $thema->find($id);
 
-        if (!$thema) {
+        if (! $thema) {
             return new WP_Error('no_item_found', sprintf('Subthema with ID [%d] not found', $id), [
                 'status' => 404,
             ]);
@@ -94,12 +94,12 @@ class SubthemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $subtheme->filterLanguage((string)$language);
+            $subtheme->filterLanguage((string) $language);
         }
 
         $subtheme = $subtheme->findBySlug($slug);
 
-        if (!$subtheme) {
+        if (! $subtheme) {
             return new WP_Error(
                 'no_subtheme_found',
                 sprintf('Subheme with slug [%s] not found', $slug),

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -25,8 +25,8 @@ class ThemaController extends BaseController
 
         $items = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query', $this->getPaginatorParams($request)))
-			->query($this->getOrderClause($orderBy, $order))
-			->query([
+            ->query($this->getOrderClause($orderBy, $order))
+            ->query([
                 'post_status' => $this->getPostStatus($request)
             ])
             ->hide(['items']);
@@ -36,7 +36,7 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $items->filterLanguage((string) $language);
+            $items->filterLanguage((string)$language);
         }
 
         $data = $items->all();
@@ -52,7 +52,7 @@ class ThemaController extends BaseController
      */
     public function getThema(WP_REST_Request $request)
     {
-        $id = (int) $request->get_param('id');
+        $id = (int)$request->get_param('id');
 
         $thema = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query/single', []))
@@ -63,12 +63,12 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $thema->filterLanguage((string) $language);
+            $thema->filterLanguage((string)$language);
         }
 
         $thema = $thema->find($id);
 
-        if (! $thema) {
+        if (!$thema) {
             return new WP_Error('no_item_found', sprintf('Thema with ID [%d] not found', $id), [
                 'status' => 404,
             ]);
@@ -95,12 +95,12 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $theme->filterLanguage((string) $language);
+            $theme->filterLanguage((string)$language);
         }
 
         $theme = $theme->findBySlug($slug);
 
-        if (! $theme) {
+        if (!$theme) {
             return new WP_Error(
                 'no_theme_found',
                 sprintf('Theme with slug [%s] not found', $slug),

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -36,7 +36,7 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $items->filterLanguage((string)$language);
+            $items->filterLanguage((string) $language);
         }
 
         $data = $items->all();
@@ -52,7 +52,7 @@ class ThemaController extends BaseController
      */
     public function getThema(WP_REST_Request $request)
     {
-        $id = (int)$request->get_param('id');
+        $id = (int) $request->get_param('id');
 
         $thema = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query/single', []))
@@ -63,12 +63,12 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $thema->filterLanguage((string)$language);
+            $thema->filterLanguage((string) $language);
         }
 
         $thema = $thema->find($id);
 
-        if (!$thema) {
+        if (! $thema) {
             return new WP_Error('no_item_found', sprintf('Thema with ID [%d] not found', $id), [
                 'status' => 404,
             ]);
@@ -95,12 +95,12 @@ class ThemaController extends BaseController
         }
 
         if ($language = $request->get_param('language')) {
-            $theme->filterLanguage((string)$language);
+            $theme->filterLanguage((string) $language);
         }
 
         $theme = $theme->findBySlug($slug);
 
-        if (!$theme) {
+        if (! $theme) {
             return new WP_Error(
                 'no_theme_found',
                 sprintf('Theme with slug [%s] not found', $slug),

--- a/src/Base/RestAPI/Controllers/ThemaController.php
+++ b/src/Base/RestAPI/Controllers/ThemaController.php
@@ -25,9 +25,8 @@ class ThemaController extends BaseController
 
         $items = (new Thema())
             ->query(apply_filters('owc/pdc/rest-api/themas/query', $this->getPaginatorParams($request)))
-            ->query([
-                'order' => $order,
-                'orderby' => $orderBy,
+			->query($this->getOrderClause($orderBy, $order))
+			->query([
                 'post_status' => $this->getPostStatus($request)
             ])
             ->hide(['items']);


### PR DESCRIPTION
Allow sorting parameters, mainly to get PDC items sorted by name, but universally implemented.

While retaining the pre-existing sorting for backward compatibility, the following URL parameters now determine sorting;

`orderby` -> the field or comma sep fields to sort on, example; `post_date,ID`
`order` -> the order, ASC or DESC, example; `DESC,ASC` 

sort by date DESC, ID DESC can be achieved by

`orderby=post_date,ID&order=DESC,DESC` 

but also by

`orderby=post_date,ID&order=DESC` 

Sorting by post-title, ASC

`orderby=post_title&order=ASC` 

etc.

---

First commit changed whitespace because the supplied .editorconfig file does not match the actual coding standards used. Will correct and do second commit.
