### PR TITLE
Add settings for PDC plugin in construct function, like in OpenPub plugin

### DIFF
--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -54,6 +54,7 @@ class Plugin
         $this->loader = new Loader();
         $this->config = new Config($this->rootPath . '/config');
         $this->config->setProtectedNodes(['core']);
+        $this->settings = SettingsPageOptions::make();
     }
 
     /**


### PR DESCRIPTION
Hi Yard,

In een thema waarin we de PDC plugin gebruiken, willen we de PDC plugin classes zoals de ItemController gebruiken. Om die reden laden we de Plugin class in. Echter krijgen we een fatal error: `PHP Fatal error:  Uncaught Error: Call to a member function useShowOn() on null in C:\Users\eyal_\Local Sites\sittard-geleennl\app\public_html\wp-content\plugins\pdc-base\src\Base\RestAPI\Controllers\ItemController.php:164`

Met de toevoeging in deze PR is dit probleem opgelost. Dit stukje code in de __construct van de plugin staat wél in de OpenPub plugin, maar niet hier in de PDC plugin.